### PR TITLE
feature/NR-9 - Add Slider component to wrap and scroll NewsFilters ca…

### DIFF
--- a/src/components/BannersList/styles.module.css
+++ b/src/components/BannersList/styles.module.css
@@ -4,6 +4,10 @@
   width: 100%;
   gap: 12px;
   box-sizing: border-box;
+}
+
+
+@media (max-width: 768px) {
   max-height: 1200px;
   overflow-y: auto;
 }

--- a/src/components/Categories/Categories.jsx
+++ b/src/components/Categories/Categories.jsx
@@ -1,28 +1,35 @@
 import styles from './styles.module.css'
+import {forwardRef} from "react";
 
-const Categories = ({categories, setSelectedCategory, selectedCategory}) => {
+const Categories = forwardRef(
+  (props, ref) => {
 
-  return (
-    <div className={styles.categories}>
+    const {categories, setSelectedCategory, selectedCategory} = props
 
-      <button
-        onClick={() => setSelectedCategory(null)}
-        className={!selectedCategory ? styles.active : styles.item}
-      >
-        All
-      </button>
+    return (
+      <div ref={ref} className={styles.categories}>
 
-      {categories.map(category => {
-        return (
-          <button key={category}
-                  onClick={() => setSelectedCategory(category)}
-                  className={selectedCategory === category ? styles.active : styles.item}
-          >
-            {category}
-          </button>)
-      })}
-    </div>
-  )
-}
+        <button
+          onClick={() => setSelectedCategory(null)}
+          className={!selectedCategory ? styles.active : styles.item}
+        >
+          All
+        </button>
+
+        {categories.map(category => {
+          return (
+            <button key={category}
+                    onClick={() => setSelectedCategory(category)}
+                    className={selectedCategory === category ? styles.active : styles.item}
+            >
+              {category}
+            </button>)
+        })}
+      </div>
+    )
+  }
+)
+
+Categories.displayName = 'Categories'
 
 export default Categories

--- a/src/components/NewsFilters/NewsFilters.jsx
+++ b/src/components/NewsFilters/NewsFilters.jsx
@@ -3,6 +3,7 @@ import Categories from "../Categories/Categories.jsx";
 import Search from "../Search/Search.jsx";
 import {useFetch} from "../../helpers/hooks/useFetch.js";
 import {getCategories} from "../../api/apiNews.js";
+import Slider from "../Slider/Slider.jsx";
 
 const NewsFilters = ({filters, changeFilters}) => {
 
@@ -10,8 +11,14 @@ const NewsFilters = ({filters, changeFilters}) => {
 
   return (
     <div className={styles.filters}>
-      {dataCategories ? <Categories categories={dataCategories.categories} selectedCategory={filters.category}
-                                    setSelectedCategory={(category) => changeFilters("category", category)}/> : null}
+
+
+      {dataCategories ? (
+        <Slider>
+          <Categories categories={dataCategories.categories} selectedCategory={filters.category}
+                      setSelectedCategory={(category) => changeFilters("category", category)}/>
+        </Slider>
+      ) : null}
 
 
       <Search keywords={filters.keywords} setKeywords={(keywords) => changeFilters("keywords", keywords)}/>

--- a/src/components/Slider/Slider.jsx
+++ b/src/components/Slider/Slider.jsx
@@ -1,0 +1,26 @@
+import styles from './styles.module.css'
+import React, {useRef} from "react";
+
+const Slider = ({children, step = 150}) => {
+
+  const sliderRef = useRef(null)
+
+
+  const scrollLeft = () => {
+    sliderRef.current.scrollLeft -= step
+  }
+
+  const scrollRight = () => {
+    sliderRef.current.scrollLeft += step
+  }
+
+  return (
+    <div className={styles.slider}>
+      <button className={styles.arrow} onClick={scrollLeft}>{`<`}</button>
+      {React.cloneElement(children, {ref: sliderRef})}
+      <button className={styles.arrow} onClick={scrollRight}>{`>`}</button>
+    </div>
+  )
+}
+
+export default Slider

--- a/src/components/Slider/styles.module.css
+++ b/src/components/Slider/styles.module.css
@@ -1,0 +1,12 @@
+.slider {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+}
+
+.arrow {
+  border: none;
+  background-color: #ffffff;
+  cursor: pointer;
+}


### PR DESCRIPTION
Add Slider component to wrap and scroll NewsFilters categories

Integrates a new reusable `Slider` component to enable horizontal scrolling for categories in `NewsFilters`. Refactors `Categories` to support being used as a child of the `Slider`. Adds associated styles for the `Slider` component to ensure proper layout and appearance.